### PR TITLE
Fix decoding of IPv6 addresses on python3

### DIFF
--- a/idstools/unified2.py
+++ b/idstools/unified2.py
@@ -339,7 +339,7 @@ class EventDecoder(AbstractDecoder):
         if len(addr) == 4:
             return socket.inet_ntoa(addr)
         else:
-            parts = struct.unpack(">" + "H" * (len(addr) / 2), addr)
+            parts = struct.unpack(">" + "H" * int((len(addr) / 2)), addr)
             return ":".join("%x" % p for p in parts)
 
 class PacketDecoder(AbstractDecoder):


### PR DESCRIPTION
This fixes:

    TypeError: can't multiply sequence by non-int of type 'float'

Its not allowed to multiply a string with a float

Reason for this is:

    Python 2.7.10 (default, Sep 23 2015, 04:34:21)
    >>> 16/2
    8

    Python 3.5.0 (default, Sep 23 2015, 04:41:38)
    >>> 16/2
    8.0