### PR TITLE
add an option for idstools-u2json to print dictionary sorted by key

### DIFF
--- a/idstools/scripts/u2json.py
+++ b/idstools/scripts/u2json.py
@@ -240,6 +240,9 @@ def main():
         "--stdout", action="store_true", default=False,
         help="also log to stdout if --output is a file")
     parser.add_argument(
+        "--sort-keys", dest="sort_keys", action="store_true", default=False,
+        help="the output of dictionaries will be sorted by key")
+    parser.add_argument(
         "--verbose", action="store_true", default=False,
         help="be more verbose")
     parser.add_argument(
@@ -317,7 +320,7 @@ def main():
     try:
         for record in reader:
             try:
-                as_json = json.dumps(formatter.format(record))
+                as_json = json.dumps(formatter.format(record), sort_keys=args.sort_keys)
                 for out in outputs:
                     out.write(as_json)
                 count += 1


### PR DESCRIPTION
this is useful when looking at the output of idstools-u2json with a human eye