### PR TITLE
Add .md5 extension after URL filepath but before parameters

### DIFF
--- a/idstools/scripts/rulecat.py
+++ b/idstools/scripts/rulecat.py
@@ -256,6 +256,9 @@ class Fetch(object):
     def check_checksum(self, tmp_filename, url):
         try:
             checksum_url = url + ".md5"
+            url_parts = url.split("?")
+            if len(url_parts) == 2:
+                checksum_url = ".md5?".join(url_parts)
             local_checksum = hashlib.md5(
                 open(tmp_filename, "rb").read()).hexdigest().strip()
             remote_checksum_buf = io.BytesIO()


### PR DESCRIPTION
This 3-line patch will add the ".md5" extension to the filepath portion of the URL, even if the full URL contains parameters following a "?" delimiter in the URL.  Eg, if the URL is **hxxps://example.com/path/rulefile.gz?oinkcode=blahblah** it will check for the hashfile at **hxxps://example.com/path/rulefile.gz.md5?oinkcode=blahblah**

See Issue #81.