### PR TITLE
eve2pcap:  fix handling of IPv6 addresses

### DIFF
--- a/idstools/scripts/eve2pcap.py
+++ b/idstools/scripts/eve2pcap.py
@@ -160,7 +160,10 @@ def payload2packet(event):
     if not "payload" in event:
         return None, None
     payload = base64.b64decode(event["payload"])
-    packet = IP(src=event["src_ip"], dst=event["dest_ip"])
+    if ':' in event["src_ip"]:
+        packet = IPv6(src=event["src_ip"], dst=event["dest_ip"])
+    else:
+        packet = IP(src=event["src_ip"], dst=event["dest_ip"])
     if event["proto"] == "TCP":
         packet = packet / TCP(sport=event["src_port"], dport=event["dest_port"])
     elif event["proto"] == "UDP":


### PR DESCRIPTION
This fixes the following error when using `idstools-eve2pcap` (version 0.6.4) and `scapy` (version 2.4.4) under python 3 (version 3.8) with json events containing IPv6 src and dest addresses:

`       "Traceback (most recent call last):", 
        "  File \"/usr/local/lib/python3.8/dist-packages/scapy-2.4.5rc1.dev2-py3.8.egg/scapy/fields.py\", line 758, in h2i", 
        "    inet_aton(x)", 
        "OSError: illegal IP address string passed to inet_aton", 
        "", 
        "During handling of the above exception, another exception occurred:", 
        "", 
        "Traceback (most recent call last):", 
        "  File \"/usr/local/bin/idstools-eve2pcap\", line 12, in <module>", 
        "    sys.exit(main())", 
        "  File \"/usr/local/lib/python3.8/dist-packages/idstools/scripts/eve2pcap.py\", line 239, in main", 
        "    hdr, packet = payload2packet(event)", 
        "  File \"/usr/local/lib/python3.8/dist-packages/idstools/scripts/eve2pcap.py\", line 163, in payload2packet", 
        "    packet = IP(src=event[\"src_ip\"], dst=event[\"dest_ip\"])", 
        "  File \"/usr/local/lib/python3.8/dist-packages/scapy-2.4.5rc1.dev2-py3.8.egg/scapy/base_classes.py\", line 392, in __call__", 
        "    i.__init__(*args, **kargs)", 
        "  File \"/usr/local/lib/python3.8/dist-packages/scapy-2.4.5rc1.dev2-py3.8.egg/scapy/packet.py\", line 171, in __init__", 
        "    self.fields[fname] = self.get_field(fname).any2i(self, value)", 
        "  File \"/usr/local/lib/python3.8/dist-packages/scapy-2.4.5rc1.dev2-py3.8.egg/scapy/fields.py\", line 793, in any2i", 
        "    return self.h2i(pkt, x)", 
        "  File \"/usr/local/lib/python3.8/dist-packages/scapy-2.4.5rc1.dev2-py3.8.egg/scapy/fields.py\", line 760, in h2i", 
        "    return Net(x)", 
        "  File \"/usr/local/lib/python3.8/dist-packages/scapy-2.4.5rc1.dev2-py3.8.egg/scapy/base_classes.py\", line 165, in __init__", 
        "    self.start = self.ip2int(net) >> inv_mask << inv_mask", 
        "  File \"/usr/local/lib/python3.8/dist-packages/scapy-2.4.5rc1.dev2-py3.8.egg/scapy/base_classes.py\", line 143, in ip2int", 
        "    \"!I\", socket.inet_aton(cls.name2addr(addr))", 
        "  File \"/usr/local/lib/python3.8/dist-packages/scapy-2.4.5rc1.dev2-py3.8.egg/scapy/base_classes.py\", line 130, in name2addr", 
        "    socket.getaddrinfo(name, None, cls.family)", 
        "  File \"/usr/lib/python3.8/socket.py\", line 918, in getaddrinfo", 
        "    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):", 
        "socket.gaierror: [Errno -9] Address family for hostname not supported"
`

Basically, scapy has support for IPv6 but requires the `eve2pcap.py` script to distinguish between IPv4 and IPv6 when constructing a packet to dump as PCAP.  