### PR TITLE
Suggestion: Add check in rulecat.py if sid is None as otherwise script aborts

### DIFF
--- a/idstools/scripts/rulecat.py
+++ b/idstools/scripts/rulecat.py
@@ -39,6 +39,7 @@ import types
 import shutil
 import glob
 import io
+from pprint import pprint
 
 if sys.argv[0] == __file__:
     sys.path.insert(
@@ -549,6 +550,10 @@ def build_rule_map(rules):
     rulemap = {}
 
     for rule in rules:
+        if rule["sid"] is None:
+            print("error in parsing rule, id is missing")
+            pprint(vars(rule))
+            sys.exit(1)
         if rule.id not in rulemap:
             rulemap[rule.id] = rule
         else:


### PR DESCRIPTION


Hi,
recently I was running rulecat.py but unfortunately I had an error in my local.rules file but as I had over 250 local rules in that file I could not figure out where exactly the problem was as the script just aborted in the following line with an error ("None can not be converted to int" if I remember well)
https://github.com/security-companion/py-idstools/blob/7c567d3ccbf58a50c3964d7115d2745f6c353821/idstools/rule.py#LL127C9-L127C46

Therefore I would like to suggest the following change which adds a print of the rule that caused the failure which then makes fixing the syntax easier.

Looking forward to your thought.
security-companion
